### PR TITLE
Fix for clashing cli args

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.krux</groupId>
   <artifactId>kafka-client-libs</artifactId>
-  <version>2.0.0</version>
+  <version>2.1.0</version>
   
     <build>
         <plugins>

--- a/src/main/java/com/krux/kafka/consumer/KafkaConsumer.java
+++ b/src/main/java/com/krux/kafka/consumer/KafkaConsumer.java
@@ -58,6 +58,8 @@ public class KafkaConsumer {
         _consumerPollTimeout = Long.parseLong(consumerProps.getProperty("consumer.poll.timeout"));
         // Remove the consumer poll interval so all properties can be passed to KafkaConsumer() clas
         consumerProps.remove("consumer.poll.timeout");
+        // Required to allow an application to run both consumer and producer libraries at the same time
+        consumerProps.setProperty("bootstrap.servers", consumerProps.getProperty("consumer.bootstrap.servers"));
 
         for ( String topic : topicMap.keySet() ) {
             String normalizedTopic = topic.replace( ".", "_" );
@@ -135,7 +137,7 @@ public class KafkaConsumer {
 
         OptionSpec<String> kafkaBrokers = parser
                 .accepts(
-                        "bootstrap.servers",
+                        "consumer.bootstrap.servers",
                         "This is for bootstrapping and the producer will only use it for getting metadata (topics, partitions and replicas). The socket connections for sending the actual data will be established based on the broker information returned in the metadata. The format is host1:port1,host2:port2, and the list can be a subset of brokers or a VIP pointing to a subset of brokers." )
                 .withOptionalArg().ofType( String.class ).defaultsTo( "localhost:9092" );
 

--- a/src/main/java/com/krux/kafka/producer/KafkaProducer.java
+++ b/src/main/java/com/krux/kafka/producer/KafkaProducer.java
@@ -45,6 +45,8 @@ public class KafkaProducer {
 
     public KafkaProducer( Properties props, String topic ) {
         LOG.warn( "Producer properties: " + props.toString() );
+        // Required to allow an application to run both consumer and producer libraries at the same time
+        props.setProperty("bootstrap.servers", props.getProperty("producer.bootstrap.servers"));
         _producer = new org.apache.kafka.clients.producer.KafkaProducer<byte[], byte[]>( props );
         _producers.add( _producer );
         _topic = topic;
@@ -52,6 +54,8 @@ public class KafkaProducer {
 
     public KafkaProducer( OptionSet options, String topic ) {
         Properties props = PropertiesUtils.createPropertiesFromOptionSpec( options );
+        // Required to allow an application to run both consumer and producer libraries at the same time
+        props.setProperty("bootstrap.servers", props.getProperty("producer.bootstrap.servers"));
         LOG.warn( "Producer properties: " + props.toString() );
         _producer = new org.apache.kafka.clients.producer.KafkaProducer<byte[], byte[]>( props );
         _producers.add( _producer );
@@ -109,7 +113,7 @@ public class KafkaProducer {
 
         OptionSpec<String> kafkaBrokers = parser
                 .accepts(
-                        "bootstrap.servers",
+                        "producer.bootstrap.servers",
                         "A list of host/port pairs to use for establishing the initial connection to the Kafka cluster. The client will make use of all servers irrespective of which servers are specified here for bootstrapping—this list only impacts the initial hosts used to discover the full set of servers. This list should be in the form host1:port1,host2:port2,.... Since these servers are just used for the initial connection to discover the full cluster membership (which may change dynamically), this list need not contain the full set of servers (you may want more than one, though, in case a server is down)." )
                 .withOptionalArg().ofType( String.class ).defaultsTo( "localhost:9092" );
         OptionSpec<Integer> kafkaAckType = parser


### PR DESCRIPTION
This allows an application to run unique broker configs for kafka consumer and producer.