### PR TITLE
Make sure client-id is unique

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.krux</groupId>
   <artifactId>kafka-client-libs</artifactId>
-  <version>2.1.0</version>
+  <version>2.1.1</version>
   
     <build>
         <plugins>

--- a/src/main/java/com/krux/kafka/consumer/ConsumerThread.java
+++ b/src/main/java/com/krux/kafka/consumer/ConsumerThread.java
@@ -7,8 +7,6 @@ import org.apache.kafka.common.errors.WakeupException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.PrintWriter;
-import java.io.StringWriter;
 import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicBoolean;
 

--- a/src/main/java/com/krux/kafka/consumer/KafkaConsumer.java
+++ b/src/main/java/com/krux/kafka/consumer/KafkaConsumer.java
@@ -70,6 +70,10 @@ public class KafkaConsumer {
             List<org.apache.kafka.clients.consumer.KafkaConsumer<byte[], byte[]>> consumers = new ArrayList<>();
             // Read thread count for topic and create that many consumers
             for (int i = 0; i < topicMap.get(topic); i++) {
+                // An id string to pass to the server when making requests. The purpose of this is to be able to track the
+                // source of requests beyond just ip/port by allowing a logical application name to be included in server-side
+                // request logging.
+                consumerProps.setProperty("client.id", normalizedConsumerGroupId + "_" + i);
                 consumers.add(new org.apache.kafka.clients.consumer.KafkaConsumer<byte[], byte[]>( consumerProps ));
             }
             _topicConsumers.put( topic, consumers);


### PR DESCRIPTION
I saw an error related to consumers having the same client-id on the personalization kafka consumer. The other libraries probably obfuscate this log so I had not seen it until now. 