### PR TITLE
W-8437828 deploy updated jar to correct JFrog online URL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.krux</groupId>
   <artifactId>kafka-client-libs</artifactId>
-  <version>3.0.4</version>
+  <version>3.0.5</version>
   
     <build>
         <plugins>
@@ -89,7 +89,7 @@
         <repository>
             <id>kruxmvn</id>
             <name>kruxmvn-releases</name>
-            <url>http://kruxmvn.jfrog.io/kruxmvn/libs-releases-local</url>
+            <url>https://kruxmvn.jfrog.io/artifactory/libs-releases/</url>
         </repository>
     </distributionManagement>
     


### PR DESCRIPTION
This will deploy latest dependency-updates in pom.xml as new version 3.0.5. The last successful deploy happened before JFrog renamed its repo URL and it took a couple of iterations for me to sort this out.

As we are looking to update the Mesos streaming service we will need dev eyes on this, and there may need to be other updates as the APIs change up the 3 times annually. @rahulvsingh-sf please advise.